### PR TITLE
Remove 'Copy model' icon from the SAE

### DIFF
--- a/src/app/main/apps/noctua-annotations/noctua-annotations.component.html
+++ b/src/app/main/apps/noctua-annotations/noctua-annotations.component.html
@@ -1,35 +1,4 @@
 <div class="w-full h-full" fxLayout="row" fxLayoutAlign="start start">
-  <div class="noc-sidemenu" fxLayout="column" fxLayoutAlign="start center">
-
-    <button mat-icon-button color="" class="noc-rounded-button"
-      [ngClass]="{'noc-active': noctuaCommonMenuService.selectedLeftPanel === LeftPanel.camForm}"
-      (click)="openCamForm()" matTooltip="Model Details" [matTooltipPosition]="'above'" [matTooltipShowDelay]="1500">
-      <fa-icon [icon]="['fas', 'info-circle']"></fa-icon>
-    </button>
-    <!--     <button mat-icon-button color="" class="noc-rounded-button"
-      [ngClass]="{'noc-active': noctuaCommonMenuService.selectedLeftPanel === LeftPanel.findReplace}"
-      (click)="openSearch()" matTooltip="Find and replace" [matTooltipPosition]="'above'" [matTooltipShowDelay]="1500">
-      <fa-icon [icon]="['fas', 'search']"></fa-icon>
-    </button> -->
-    <button mat-icon-button color="" class="noc-rounded-button"
-      [ngClass]="{'noc-active': noctuaCommonMenuService.selectedLeftPanel === LeftPanel.camTermsSummary}"
-      (click)="openTermsSummary()" matTooltip="terms summary" [matTooltipPosition]="'above'"
-      [matTooltipShowDelay]="1500">
-      <fa-icon [icon]="['fas', 'list']"></fa-icon>
-    </button>
-    <!--    <button mat-icon-button color="" class="noc-rounded-button"
-      [ngClass]="{'noc-active': noctuaCommonMenuService.selectedLeftPanel === LeftPanel.camStats}"
-      (click)="openCamStats()" matTooltip="GO CAM Statistics" [matTooltipPosition]="'above'"
-      [matTooltipShowDelay]="1500">
-      <fa-icon [icon]="['fas', 'chart-bar']"></fa-icon>
-    </button> -->
-    <button mat-icon-button color="" class="noc-rounded-button" (click)="openCopyModel()"
-      [ngClass]="{'noc-active': noctuaCommonMenuService.selectedLeftPanel === LeftPanel.copyModel}"
-      matTooltip="Make a copy of this model" [matTooltipPosition]="'above'" [matTooltipShowDelay]="1500">
-      <fa-icon [icon]="['fas', 'clone']"></fa-icon>
-    </button>
-  </div>
-
   <div class="w-full h-full" fxLayout="column" fxLayoutAlign="start start">
     <div *ngIf="!noctuaUserService.user" class="noc-not-loggedin" fxLayout="row" fxLayoutAlign="center center">
       Not Logged In: You can only view existing annotations

--- a/src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html
+++ b/src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html
@@ -31,18 +31,6 @@
     </div>
   </div>
   }
-  <!--   <div class="flex">
-    <button mat-button class="noc-toolbar-button noc-rounded-button" (click)="undoModel()"
-      matTooltip="Undo Last Changes" [matTooltipPosition]="'after'" [matTooltipShowDelay]="1000">
-      <fa-icon [icon]="['fas', 'undo']"></fa-icon>
-      Undo
-    </button>
-    <button mat-button class="noc-toolbar-button noc-rounded-button" (click)="redoModel()"
-      matTooltip="Redo Last Changes" [matTooltipPosition]="'after'" [matTooltipShowDelay]="1000">
-      <fa-icon [icon]="['fas', 'undo']"></fa-icon>
-      Redo
-    </button>
-  </div> -->
 
   <div class="noc-br noc-bl px-4">
     <button mat-button class="noc-toolbar-button noc-rounded-button" (click)="openCamForm()"
@@ -51,12 +39,6 @@
       <div class="noc-comments-badge">
         {{cam?.comments.length}}
       </div>
-    </button>
-  </div>
-  <div class="noc-br px-4">
-    <button mat-button color="" class="noc-toolbar-button noc-rounded-button" (click)="openCopyModel()"
-      matTooltip="Make a copy of this model" [matTooltipPosition]="'after'" [matTooltipShowDelay]="1500">
-      <fa-icon [icon]="['fas', 'clone']"></fa-icon>
     </button>
   </div>
   @if (cam.state) {


### PR DESCRIPTION
### Issues

- https://github.com/geneontology/noctua-standard-annotations/issues/77

### Changes

- Removed the copy model button from the toolbar and the copy model sidebar

### Tests

- [ ] Verify the Copy Model button and sidebar are no longer visible in the SAE

cc @pgaudet @vanaukenk @kltm @thomaspd