### PR TITLE
Add quick ISS evidence menu to annotation form

### DIFF
--- a/.plans/feature/quick-add-iss-evidence.md
+++ b/.plans/feature/quick-add-iss-evidence.md
@@ -1,0 +1,63 @@
+# Task: Quick Add ISS Evidence to SAE
+
+**Status:** ACTIVE
+**Issue:** #78
+**Branch:** issue-78-quick-add-iss
+
+## Goal
+
+Add a `more_vert` menu button on each evidence row in the annotation form with an "Add ISS Evidence" option that fills in ECO:0000250 + GO_REF:0000024.
+
+## Context
+
+- **Related files:**
+  - `src/@noctua.form/noctua-form-config.ts` — evidence auto-populate config (has `nd`, needs `iss`)
+  - `src/app/main/apps/noctua-annotations/forms/annotation-form/annotation-form.component.html` — annotation form template (evidence row at line 72-83)
+  - `src/app/main/apps/noctua-annotations/forms/annotation-form/annotation-form.component.ts` — annotation form component
+- **Triggered by:** [Issue #78](https://github.com/geneontology/noctua-standard-annotations/issues/78)
+- **VPE reference:** VPE has this in `entity-form.component.ts:261`
+
+## Current State
+
+- The evidence row (line 72-83 in template) has 3 autocomplete fields + an empty `<div fxFlex="40px"></div>` placeholder
+- The form works with in-memory data (patchValue), no API calls needed — same as VPE
+- `_addRootTerm()` (line 170) already shows the pattern: patch evidenceCode + reference from `noctuaFormConfig.evidenceAutoPopulate`
+
+## Steps
+
+### Phase 1: Config
+
+- [ ] Add `iss` to `evidenceAutoPopulate` in `src/@noctua.form/noctua-form-config.ts` (line ~491)
+  - `evidence.id`: `ECO:0000250`, `evidence.label`: `sequence similarity evidence used in manual assertion`
+  - `reference`: `GO_REF:0000024`
+
+### Phase 2: UI
+
+- [ ] Replace the empty `<div fxFlex="40px"></div>` on the evidence row (line 81) with a `more_vert` menu button + mat-menu containing "Add ISS Evidence"
+- [ ] Add `addEvidenceISS()` method to `annotation-form.component.ts` that patches evidenceCode and reference using `noctuaFormConfig.evidenceAutoPopulate.iss` (same pattern as `_addRootTerm`)
+
+### Phase 3: Build
+
+- [ ] Run `npm run build`
+
+## Recovery Checkpoint
+
+> **Last completed action:** Branch created: `issue-78-quick-add-iss`
+> **Next immediate action:** Add ISS config to noctua-form-config.ts
+> **Uncommitted changes:** None
+
+## Files Modified
+
+| File | Action | Status |
+| ---- | ------ | ------ |
+| `src/@noctua.form/noctua-form-config.ts` | Add ISS to evidenceAutoPopulate | pending |
+| `src/app/.../annotation-form/annotation-form.component.html` | Replace empty div with menu button | pending |
+| `src/app/.../annotation-form/annotation-form.component.ts` | Add addEvidenceISS() method | pending |
+
+## Blockers
+
+- None
+
+## Notes
+
+- This is form-level (in-memory patchValue), no service/API changes needed.

--- a/src/@noctua.form/noctua-form-config.ts
+++ b/src/@noctua.form/noctua-form-config.ts
@@ -487,6 +487,13 @@ export const noctuaFormConfig = {
         'label': 'no biological data found used in manual assertion'
       },
       reference: 'GO_REF:0000015'
+    },
+    iss: {
+      evidence: {
+        'id': 'ECO:0000250',
+        'label': 'sequence similarity evidence used in manual assertion'
+      },
+      reference: 'GO_REF:0000024'
     }
   },
   rootNode: rootNode,

--- a/src/app/main/apps/noctua-annotations/forms/annotation-form/annotation-form.component.html
+++ b/src/app/main/apps/noctua-annotations/forms/annotation-form/annotation-form.component.html
@@ -78,28 +78,21 @@
             [label]="annotationActivity?.reference.label"></noc-term-autocomplete>
           <noc-term-autocomplete fxFlex="35" class="p-1" formControlName="withFrom"
             [label]="annotationActivity?.with.label" [autocompleteType]="AutocompleteType.WITH"></noc-term-autocomplete>
-          <div fxFlex="40px"></div>
-          @if(evidences.length>1) {
-          <button mat-icon-button (click)="deleteEvidence(i)" class="text-warn">
-            <fa-icon [icon]="['far', 'trash-alt']"></fa-icon>
+          <button mat-icon-button class="noc-action-button" fxFlex="40px" [matMenuTriggerFor]="evidenceMenu">
+            <mat-icon>more_vert</mat-icon>
           </button>
-          }
+          <mat-menu #evidenceMenu="matMenu" class="noc-dropdown-menu">
+            <button mat-menu-item class="" (click)="addEvidenceISS(i)">
+              Add ISS Evidence
+            </button>
+          </mat-menu>
         </div>
       </div>
-      <!--    <div class="pl-4 py-4">
-        <a (click)="addEvidence()" class="cursor-pointer" color="primary">
-          Add Another Evidence
-        </a>
-      </div> -->
       <div class="noc-section-header pr-4" fxLayout="row" fxLayoutAlign="start center">
         <div class="noc-section-heading">
           Extensions
         </div>
         <span fxFlex></span>
-        <!--  <button mat-stroked-button (click)="addExtension()" type="submit" class="noc-xs noc-rounded-button"
-          color="primary">
-          Add
-        </button> -->
       </div>
       <div formArrayName="annotationExtensions" class="px-3 pt-1" fxLayout="column" fxLayoutAlign="start center">
         <div *ngFor="let item of annotationExtensions.controls; let i=index" [formGroupName]="i" class="w-full">

--- a/src/app/main/apps/noctua-annotations/forms/annotation-form/annotation-form.component.ts
+++ b/src/app/main/apps/noctua-annotations/forms/annotation-form/annotation-form.component.ts
@@ -252,6 +252,17 @@ export class AnnotationFormComponent implements OnInit, OnDestroy {
     return this.dynamicForm.get('annotationComments') as FormArray;
   }
 
+  addEvidenceISS(index: number) {
+    const evidenceGroup = this.evidences.at(index) as FormGroup;
+    evidenceGroup.patchValue({
+      evidenceCode: {
+        id: noctuaFormConfig.evidenceAutoPopulate.iss.evidence.id,
+        label: noctuaFormConfig.evidenceAutoPopulate.iss.evidence.label
+      },
+      reference: noctuaFormConfig.evidenceAutoPopulate.iss.reference
+    });
+  }
+
   addEvidence() {
     this.evidences.push(this.fb.group({
       evidenceCode: '',


### PR DESCRIPTION
### Issues

- https://github.com/geneontology/noctua-standard-annotations/issues/78

### Changes

- Added a more options menu button on the evidence row in the annotation form
- Menu includes "Add ISS Evidence" option that fills in ECO:0000250 + GO_REF:0000024

### Tests

- [ ] Open the annotation form, click the three-dot menu on the evidence row, and select "Add ISS Evidence"
- [ ] Verify evidence code is set to ECO:0000250 and reference to GO_REF:0000024

cc @pgaudet @vanaukenk @kltm @thomaspd